### PR TITLE
refatorando funcoes de add e remover tags 

### DIFF
--- a/src/Components/UserRepositories/Repositorie.jsx
+++ b/src/Components/UserRepositories/Repositorie.jsx
@@ -7,13 +7,13 @@ const Repositorie = ({
   html_url,
   description,
   language,
-  updated_at,
   created_at,
   tags,
   stargazers_count,
   addTag,
   deleteTag,
   index,
+  id,
 }) => {
   function calcDate(data) {
     const now = new Date();
@@ -38,6 +38,7 @@ const Repositorie = ({
             deleteTag={deleteTag}
             addTag={addTag}
             index={index}
+            id={id}
           />
         }
       </ul>

--- a/src/Components/UserRepositories/Tag/Tag.jsx
+++ b/src/Components/UserRepositories/Tag/Tag.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./Tag.module.css";
 import TagModal from "./TagModal";
 
-const Tag = ({ tags, addTag, deleteTag, index }) => {
+const Tag = ({ tags, addTag, deleteTag, index, id }) => {
   const [tagList, setTagList] = React.useState([]);
   const [modal, setModal] = React.useState(false);
 
@@ -39,6 +39,7 @@ const Tag = ({ tags, addTag, deleteTag, index }) => {
           deleteTag={deleteTag}
           addTag={addTag}
           index={index}
+          id={id}
         />
       )}
     </>

--- a/src/Components/UserRepositories/Tag/TagModal.jsx
+++ b/src/Components/UserRepositories/Tag/TagModal.jsx
@@ -3,7 +3,7 @@ import Input from "../../Forms/Input";
 import styles from "./TagModal.module.css";
 import { ReactComponent as Search } from "../../../Assets/search.svg";
 
-const TagModal = ({ tags, toogleModal, deleteTag, addTag, index }) => {
+const TagModal = ({ tags, toogleModal, deleteTag, addTag, index, id }) => {
   const [tagInput, setTagInput] = React.useState("");
 
   function handleOutsideClick(event) {
@@ -14,16 +14,16 @@ const TagModal = ({ tags, toogleModal, deleteTag, addTag, index }) => {
     setTagInput(target.value);
   }
 
-  function handleClick(index) {
+  function handleClick(id) {
     if (tagInput.length >= 1) {
-      addTag(index, tagInput.split(","));
+      addTag(id, tagInput.split(","));
       setTagInput("");
       toogleModal();
     } else toogleModal();
   }
 
-  function handleDeleteTag(index, i) {
-    deleteTag(index, i);
+  function handleDeleteTag(id, i) {
+    deleteTag(id, i);
     tags.splice(i, 1);
   }
 
@@ -46,7 +46,7 @@ const TagModal = ({ tags, toogleModal, deleteTag, addTag, index }) => {
                 className={styles.tagsModal}
                 key={tag}
                 onClick={() => {
-                  handleDeleteTag(index, i);
+                  handleDeleteTag(id, i);
                 }}
               >
                 {tag}
@@ -58,7 +58,7 @@ const TagModal = ({ tags, toogleModal, deleteTag, addTag, index }) => {
         {/* <section>
         <h2>Sugestões</h2>
       </section> */}
-        <button onClick={() => handleClick(index)} className={styles.btnSalvar}>
+        <button onClick={() => handleClick(id)} className={styles.btnSalvar}>
           Salvar
         </button>
         <button onClick={() => toogleModal()} className={styles.btnCancelar}>

--- a/src/Components/UserRepositories/UserRepositories.jsx
+++ b/src/Components/UserRepositories/UserRepositories.jsx
@@ -81,15 +81,26 @@ const UserRepositories = () => {
     } else return setFilter(repositories);
   }
 
-  function addTag(i, tag) {
-    const tags = repositories[i].tags;
-    repositories[i].tags = [...tags, ...tag];
-    setRepositories([...repositories]);
+  function addTag(repoId, tag) {
+    const newRepositories = repositories.map((repo) => {
+      if (repo.id === repoId) return { ...repo, tags: [...repo.tags, ...tag] };
+
+      return repo;
+    });
+
+    setRepositories(newRepositories);
   }
 
-  function deleteTag(index, i) {
-    repositories[index].tags.splice(i, 1);
-    setRepositories([...repositories]);
+  function deleteTag(repoId, i) {
+    const newRepositories = repositories.map((repo) => {
+      if (repo.id === repoId) {
+        repo.tags.splice(i, 1);
+        return { ...repo, tags: [...repo.tags] };
+      }
+
+      return repo;
+    });
+    setRepositories(newRepositories);
   }
 
   return (

--- a/src/Components/Users.jsx
+++ b/src/Components/Users.jsx
@@ -27,7 +27,7 @@ const Users = () => {
       <ul className={styles.users}>
         {users.map((user, index) => (
           <User
-            kye={index}
+            key={user.id}
             name={user.name}
             login={user.login}
             avatar={user.avatar_url}


### PR DESCRIPTION
refatorando funções de add e remover tags para usar o id do repositório  e não o index. Existia um erro que ao pesquisa um o repositório o index dele na lista era alterado e no momento de alterar a tag no novo index adicionar em outro repositório que era o desejado.